### PR TITLE
Fix title localisedtext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # UsabILIty Hub
 
-Contains Website, Docs and Generator for ilidata.xml of https://models.opengis.ch
-
-https://usabilityhub.opengis.ch
+Contains Website, Docs and Generator for ilidata.xml of https://models.opengis.ch and is published on https://usabilityhub.opengis.ch

--- a/generator/generator.py
+++ b/generator/generator.py
@@ -42,7 +42,7 @@ for xmlitem in document.findall(METADATA_XML_PATH, namespaces=namespaces):
 
     # Title (multilingual)
     item['titles'] = {}
-    titles_xmlitems = xmlitem.findall('./ili:title/ili:DatasetIdx16.MultilingualMText/ili:LocalisedText/ili:DatasetIdx16.LocalisedMText', namespaces=namespaces)
+    titles_xmlitems = xmlitem.findall('./ili:title/ili:DatasetIdx16.MultilingualText/ili:LocalisedText/ili:DatasetIdx16.LocalisedText', namespaces=namespaces)
     for title_xmlitem in titles_xmlitems:
         language = title_xmlitem.find('./ili:Language', namespaces=namespaces).text
         title = title_xmlitem.find('./ili:Text', namespaces=namespaces).text

--- a/website/_services/konzept.md
+++ b/website/_services/konzept.md
@@ -32,14 +32,14 @@ Weitere Server/Repositories können über das `ilisite.xml` verbunden werden. Di
   <version>2021-01-06</version>
   <owner>mailto:david@opengis.ch</owner>
   <title>
-    <DatasetIdx16.MultilingualMText>
+    <DatasetIdx16.MultilingualText>
       <LocalisedText>
-        <DatasetIdx16.LocalisedMText>
+        <DatasetIdx16.LocalisedText>
           <Language>de</Language>
           <Text>Einfaches Styling und Tree (OPENGIS.ch)</Text>
-        </DatasetIdx16.LocalisedMText>
+        </DatasetIdx16.LocalisedText>
       </LocalisedText>
-    </DatasetIdx16.MultilingualMText>
+    </DatasetIdx16.MultilingualText>
   </title>
   <categories>
     <DatasetIdx16.Code_>

--- a/website/benutzerhandbuch.md
+++ b/website/benutzerhandbuch.md
@@ -291,14 +291,14 @@ Damit das Metakonfigurationsfile aber aufgrund eines Modellnamens (hier "Nutzung
         <version>2021-03-12</version>
         <owner>mailto:zsanett@opengis.ch</owner>
         <title>
-          <DatasetIdx16.MultilingualMText>
+          <DatasetIdx16.MultilingualText>
             <LocalisedText>
-              <DatasetIdx16.LocalisedMText>
+              <DatasetIdx16.LocalisedText>
                 <Language>de</Language>
                 <Text>Styling und Tree für PostgreSQL Projekt für den Kanton Luzern (lu.ch)</Text>
-              </DatasetIdx16.LocalisedMText>
+              </DatasetIdx16.LocalisedText>
             </LocalisedText>
-          </DatasetIdx16.MultilingualMText>
+          </DatasetIdx16.MultilingualText>
         </title>
         <shortDescription>
           <DatasetIdx16.MultilingualMText>


### PR DESCRIPTION
In http://models.interlis.ch/core/DatasetIdx16.ili the attribute title is of type `MultilingualText` and not `MultilingualMText`.